### PR TITLE
Update config.yml

### DIFF
--- a/demo/app/config/config.yml
+++ b/demo/app/config/config.yml
@@ -65,7 +65,7 @@ swiftmailer:
 # BootstrapBundle Configuration
 braincrafted_bootstrap:
     jquery_path: %kernel.root_dir%/../src/Fuz/QuickStartBundle/Resources/public/js/jquery-2.1.1.min.js
-    less_filter: lessphp
+    css_preprocessor: lessphp
     auto_configure:
       knp_menu: false
 


### PR DESCRIPTION
replaced deprecated key 'less_filter' with 'css_preprocessor' (note that the documentation of BraincraftedBootstrapBundle is out of date on this topic: https://github.com/braincrafted/bootstrap-bundle/issues/423)
